### PR TITLE
get_float and get_double added

### DIFF
--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -5,6 +5,8 @@
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <sstream>
+#include <stdexcept>
 
 #include "cs50.h"
 
@@ -23,6 +25,44 @@ void eprintf()
 {
     // TODO
 }
+
+/**
+ * Reads a line of text from standard input and returns it as a std::string;
+ * The function is used internally for reading input and handling console input
+ * stream errors. If eof or input stream corrupt (failed to read into string).
+ * The argument passed to bool *ok is used to check for eof or bad string input
+ * so it's set to false when read fails or is in eof state, and set to true
+ * otherwise.
+ */
+std::string read_input(bool *ok)
+{
+    std::string str;
+
+    // attempt to read string input into s
+    std::getline(std::cin, str);
+
+    // check if input stream in bad state (hardware failure?)
+    if (std::cin.bad())
+    {
+        // if we're here we can't recover the cin stream
+        // we only get here in case of catastrophic error so throw
+        throw (std::runtime_error("cs50::input_string: error reading input"));
+    }
+
+    if (std::cin.eof() || std::cin.fail())
+    {
+        // report bad string input via side-effect and clear cin flags
+        *ok = false;
+        std::cin.clear();
+        return std::string();
+    }
+
+    // if we're here all is ok so we set sentinel to true and return the input
+    *ok = true;
+    return str;
+}
+
+
 
 /**
  * TODO
@@ -44,30 +84,30 @@ double get_double(void)
     // attempt to take a double from the user
     while (true)
     {
-        std::string str = get_string();
-
-        // if eof, failbit or badbit return DOUBLE_MAX
-        if (str[0] == '\0')
+        bool valid;
+        std::string str = read_input(&valid);
+        // if eof or error return DBL_MAX
+        if(!valid)
         {
             return DBL_MAX;
         }
-
-        // validate input 
-        if(!isspace(str[0])) 
+        // validate input
+        if (str.length() > 0 && !isspace(str[0]))
         {
-            char* tail;
-            errno = 0;
-            double d = strtod(str.c_str(), &tail);
-            if (errno == 0 && *tail == '\0' && d > DBL_MIN && d < DBL_MAX)
+            // load string into a stringstream
+            std::istringstream is(str);
+            double d;
+
+            // if is successfully read into an double we return it
+            if (is >> d && is.eof())
             {
-                // disallow hexadecimal and exponents
+                // disallow hexadecimals and exponents
                 if (strcspn(str.c_str(), "XxEePp") == str.length())
                 {
                     return d;
                 }
             }
         }
-
         // if we're here the input was not ok so reprompt
         std::cout << "Retry: ";
     }
@@ -84,30 +124,30 @@ float get_float(void)
     // attempt to take a double from the user
     while (true)
     {
-        std::string str = get_string();
-
-        // if eof, failbit or badbit return DOUBLE_MAX
-        if (str[0] == '\0')
+        bool valid;
+        std::string str = read_input(&valid);
+        // if eof or error, return FLT_MAX
+        if(!valid)
         {
             return FLT_MAX;
         }
-
-        // validate input 
-        if(!isspace(str[0])) 
+        // validate input
+        if (str.length() > 0 && !isspace(str[0]))
         {
-            char* tail;
-            errno = 0;
-            float f = strtod(str.c_str(), &tail);
-            if (errno == 0 && *tail == '\0' && f > FLT_MIN && f < FLT_MAX)
+            // load string into a stringstream
+            std::istringstream is(str);
+            float f;
+
+            // if is successfully read into a float we return it
+            if (is >> f && is.eof())
             {
-                // disallow hexadecimal and exponents
+                // disallow hexadecimals and exponents
                 if (strcspn(str.c_str(), "XxEePp") == str.length())
                 {
                     return f;
                 }
             }
         }
-
         // if we're here the input was not ok so reprompt
         std::cout << "Retry: ";
     }
@@ -136,11 +176,15 @@ long long get_long_long(void)
  */
 std::string get_string(void)
 {
-    // TODO: check for failure
     // TODO: decide whether to return string or c_str
-    std::string s;
-    std::getline(std::cin, s);
+    bool valid;
+    std::string s = read_input(&valid);
+
+    // return empty string on invalid input
+    if (valid == false)
+    {
+        return std::string();
+    }
     return s;
 }
-
 }

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -25,10 +25,10 @@ char get_char(void)
 }
 
 /**
- * Reads a line of text from stdin via get_string(). 
- * Uses regex to match float pattern. If success, returns the input converted to a float. 
- * If input doesn't match pattern, prompts user to retry. 
- * If error stream, returns FLT_MAX
+ * Reads a line of text from standard input and returns the equivalent
+ * double as precisely as possible; if text does not represent a
+ * double or if value would cause underflow or overflow, user is
+ * prompted to retry. If line can't be read, returns DBL_MAX.
  */
 double get_double(void)
 {
@@ -44,8 +44,7 @@ double get_double(void)
             return DBL_MAX;
         }
 
-        // regex for [optional] + or - sign, followed by one of the following: either a number followed by floating point and [optional] digits, or an [optional] number followed by floating point and digits, or any number
- 
+       // validate input 
        std::regex re("(\\+|-)?\\d*(\\.\\d*)?");
 
         // on matching input attempt to convert string to double
@@ -70,10 +69,10 @@ double get_double(void)
 }
 
 /**
- * Reads a line of text from stdin via get_string(). 
- * Uses regex to match float pattern. If success, returns the input converted to a float. 
- * If input doesn't match pattern, prompts user to retry. 
- * If error stream, returns FLT_MAX
+ * Reads a line of text from standard input and returns the equivalent
+ * float as precisely as possible; if text does not represent a
+ * float or if value would cause underflow or overflow, user is
+ * prompted to retry. If line can't be read, returns FLT_MAX.
  */
 float get_float(void)
 {
@@ -89,7 +88,7 @@ float get_float(void)
             return FLT_MAX;
         }
 
-        // regex for [optional] + or - sign, followed by one of the following: either a number followed by floating point and [optional] digits, or an [optional] number followed by floating point and digits, or any number
+        // validate input
         std::regex re("(\\+|-)?\\d*(\\.\\d*)?");
 
         // on matching input attempt to convert string to float

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -82,7 +82,7 @@ double get_double(void)
         bool valid;
         std::string str = read_input(&valid);
         // if eof or error return DBL_MAX
-        if(!valid)
+        if (!valid)
         {
             return DBL_MAX;
         }
@@ -122,7 +122,7 @@ float get_float(void)
         bool valid;
         std::string str = read_input(&valid);
         // if eof or error, return FLT_MAX
-        if(!valid)
+        if (!valid)
         {
             return FLT_MAX;
         }

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -32,7 +32,7 @@ char get_char(void)
  */
 double get_double(void)
 {
-        // attempt to take an int from the user
+    // attempt to take a double from the user
     while (true)
     {
         std::string str = get_string();
@@ -77,7 +77,7 @@ double get_double(void)
  */
 float get_float(void)
 {
-            // attempt to take an float from the user
+    // attempt to take a float from the user
     while (true)
     {
         std::string str = get_string();

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -45,7 +45,8 @@ double get_double(void)
         }
 
         // regex for [optional] + or - sign, followed by one of the following: either a number followed by floating point and [optional] digits, or an [optional] number followed by floating point and digits, or any number
-        std::regex re("[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+|[0-9]+)");
+ 
+       std::regex re("(\\+|-)?\\d*(\\.\\d*)?");
 
         // on matching input attempt to convert string to double
         if (std::regex_match(str, re))
@@ -89,7 +90,7 @@ float get_float(void)
         }
 
         // regex for [optional] + or - sign, followed by one of the following: either a number followed by floating point and [optional] digits, or an [optional] number followed by floating point and digits, or any number
-        std::regex re("[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+|[0-9]+)");
+        std::regex re("(\\+|-)?\\d*(\\.\\d*)?");
 
         // on matching input attempt to convert string to float
         if (std::regex_match(str, re))
@@ -143,4 +144,7 @@ std::string get_string(void)
 
 }
 
-
+int main() {
+    double d = cs50::get_double();
+    std::cout << d << std::endl;
+}

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -1,11 +1,20 @@
+#include <cerrno>
+#include <cfloat>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <string>
+
 #include "cs50.h"
-#include <regex>
-#include <cfloat>
 
 namespace cs50
 {
+
+/** static variable which will call the constructor before 
+ * execution enters main.
+*/
+static BeforeMain init;
 
 /**
  * TODO
@@ -37,35 +46,31 @@ double get_double(void)
     {
         std::string str = get_string();
 
-        // if eof, failbit or badbit clear state and return DOUBLE_MAX
-        if (std::cin.eof() || std::cin.fail())
+        // if eof, failbit or badbit return DOUBLE_MAX
+        if (str[0] == '\0')
         {
-            std::cin.clear();
             return DBL_MAX;
         }
 
-       // validate input 
-       std::regex re("(\\+|-)?\\d*(\\.\\d*)?");
-
-        // on matching input attempt to convert string to double
-        if (std::regex_match(str, re))
+        // validate input 
+        if(!isspace(str[0])) 
         {
-            try
+            char* tail;
+            errno = 0;
+            double d = strtod(str.c_str(), &tail);
+            if (errno == 0 && *tail == '\0' && d > DBL_MIN && d < DBL_MAX)
             {
-                return std::stod(str);
-            }
-            // in case of value exceeding double size do nothing and reprompt
-            catch (const std::exception&)
-            {
-                ;
+                // disallow hexadecimal and exponents
+                if (strcspn(str.c_str(), "XxEePp") == str.length())
+                {
+                    return d;
+                }
             }
         }
 
         // if we're here the input was not ok so reprompt
         std::cout << "Retry: ";
-
     }
-
 }
 
 /**
@@ -76,38 +81,35 @@ double get_double(void)
  */
 float get_float(void)
 {
-    // attempt to take a float from the user
+    // attempt to take a double from the user
     while (true)
     {
         std::string str = get_string();
 
-        // if eof, failbit or badbit clear state and return FLT_MAX
-        if (std::cin.eof() || std::cin.fail())
+        // if eof, failbit or badbit return DOUBLE_MAX
+        if (str[0] == '\0')
         {
-            std::cin.clear();
             return FLT_MAX;
         }
 
-        // validate input
-        std::regex re("(\\+|-)?\\d*(\\.\\d*)?");
-
-        // on matching input attempt to convert string to float
-        if (std::regex_match(str, re))
+        // validate input 
+        if(!isspace(str[0])) 
         {
-            try
+            char* tail;
+            errno = 0;
+            float f = strtod(str.c_str(), &tail);
+            if (errno == 0 && *tail == '\0' && f > FLT_MIN && f < FLT_MAX)
             {
-                return std::stof(str);
-            }
-            // in case of value exceeding float size do nothing and reprompt
-            catch (const std::exception&)
-            {
-                ;
+                // disallow hexadecimal and exponents
+                if (strcspn(str.c_str(), "XxEePp") == str.length())
+                {
+                    return f;
+                }
             }
         }
 
         // if we're here the input was not ok so reprompt
         std::cout << "Retry: ";
-
     }
 }
 
@@ -142,5 +144,3 @@ std::string get_string(void)
 }
 
 }
-
-

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -69,7 +69,7 @@ char get_char(const std::string &prompt = std::string())
  * double or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read or EOF, returns DBL_MAX.
  */
-double get_double(const std::string &prompt)
+double get_double(const std::string &prompt = std::string())
 {
     // attempt to take a double from the user
     while (true)
@@ -117,7 +117,7 @@ double get_double(const std::string &prompt)
  * float or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read or EOF, returns FLT_MAX.
  */
-float get_float(const std::string &prompt)
+float get_float(const std::string &prompt = std::string())
 {
     // attempt to take a double from the user
     while (true)
@@ -165,7 +165,7 @@ float get_float(const std::string &prompt)
  * or input stream corrupt (failed to read into string) or int is out of range
  * returns INT_MAX.
  */
-int get_int(const std::string &prompt)
+int get_int(const std::string &prompt = std::string())
 {
     // attempt to take an int from the user
     while (true)
@@ -211,7 +211,7 @@ int get_int(const std::string &prompt)
  * retry. If eof or input stream corrupt (failed to read into string) or out of
  * range returns LLONG_MAX.
  */
-long long get_long_long(const std::string &prompt)
+long long get_long_long(const std::string &prompt = std::string())
 {
     // attempt to take an int from the user
     while (true)

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -1,5 +1,8 @@
 #include <iostream>
 #include <string>
+#include "cs50.h"
+#include <regex>
+#include <cfloat>
 
 namespace cs50
 {
@@ -22,21 +25,90 @@ char get_char(void)
 }
 
 /**
- * TODO
+ * Reads a line of text from stdin via get_string(). 
+ * Uses regex to match float pattern. If success, returns the input converted to a float. 
+ * If input doesn't match pattern, prompts user to retry. 
+ * If error stream, returns FLT_MAX
  */
 double get_double(void)
 {
-    // TODO
-    return 0.0;
+        // attempt to take an int from the user
+    while (true)
+    {
+        std::string str = get_string();
+
+        // if eof, failbit or badbit clear state and return DOUBLE_MAX
+        if (std::cin.eof() || std::cin.fail())
+        {
+            std::cin.clear();
+            return DBL_MAX;
+        }
+
+        // regex for [optional] + or - sign, followed by one of the following: either a number followed by floating point and [optional] digits, or an [optional] number followed by floating point and digits, or any number
+        std::regex re("[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+|[0-9]+)");
+
+        // on matching input attempt to convert string to double
+        if (std::regex_match(str, re))
+        {
+            try
+            {
+                return std::stod(str);
+            }
+            // in case of value exceeding double size do nothing and reprompt
+            catch (const std::exception&)
+            {
+                ;
+            }
+        }
+
+        // if we're here the input was not ok so reprompt
+        std::cout << "Retry: ";
+
+    }
+
 }
 
 /**
- * TODO
+ * Reads a line of text from stdin via get_string(). 
+ * Uses regex to match float pattern. If success, returns the input converted to a float. 
+ * If input doesn't match pattern, prompts user to retry. 
+ * If error stream, returns FLT_MAX
  */
 float get_float(void)
 {
-    // TODO
-    return 0.0;
+            // attempt to take an float from the user
+    while (true)
+    {
+        std::string str = get_string();
+
+        // if eof, failbit or badbit clear state and return FLT_MAX
+        if (std::cin.eof() || std::cin.fail())
+        {
+            std::cin.clear();
+            return FLT_MAX;
+        }
+
+        // regex for [optional] + or - sign, followed by one of the following: either a number followed by floating point and [optional] digits, or an [optional] number followed by floating point and digits, or any number
+        std::regex re("[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+|[0-9]+)");
+
+        // on matching input attempt to convert string to float
+        if (std::regex_match(str, re))
+        {
+            try
+            {
+                return std::stof(str);
+            }
+            // in case of value exceeding float size do nothing and reprompt
+            catch (const std::exception&)
+            {
+                ;
+            }
+        }
+
+        // if we're here the input was not ok so reprompt
+        std::cout << "Retry: ";
+
+    }
 }
 
 /**
@@ -70,3 +142,5 @@ std::string get_string(void)
 }
 
 }
+
+

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -144,7 +144,4 @@ std::string get_string(void)
 
 }
 
-int main() {
-    double d = cs50::get_double();
-    std::cout << d << std::endl;
-}
+

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -1,4 +1,5 @@
 #include <cfloat>
+#include <climits>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -25,12 +26,41 @@ void eprintf()
 }
 
 /**
- * TODO
+ * Reads a line of text from standard input and returns the equivalent
+ * char; if text does not represent a char, user is prompted to retry.
+ * If eof or input stream corrupt (failed to read into string) returns
+ * CHAR_MAX.
  */
-char get_char(void)
+char get_char(const std::string &prompt = std::string())
 {
-    // TODO
-    return '\0';
+    while (true)
+    {
+        std::string str;
+
+        // attempt to read string input, on error or EOF return CHAR_MAX
+        try
+        {
+            // a bool to handle EOF, passed to get_string by address
+            bool eof;
+            str = get_string(prompt, &eof);
+            
+            // if EOF was read we return our sentinel value here 
+            if (eof)
+            {
+                return CHAR_MAX;
+            }
+        }
+        catch (const std::runtime_error&)
+        {
+            return CHAR_MAX;
+        }
+
+        // return 1st char of str only if single char of input
+        if (str.size() == 1)
+        {
+            return str[0];
+        }
+    }
 }
 
 /**
@@ -39,7 +69,7 @@ char get_char(void)
  * double or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read or EOF, returns DBL_MAX.
  */
-double get_double(void)
+double get_double(const std::string &prompt)
 {
     // attempt to take a double from the user
     while (true)
@@ -50,7 +80,7 @@ double get_double(void)
         {
             // a bool to handle EOF, passed to get_string by address
             bool eof;
-            str = get_string(&eof);
+            str = get_string(prompt, &eof);
             // if EOF was read we return our sentinel value here 
             if (eof)
             {
@@ -78,8 +108,6 @@ double get_double(void)
                 }
             }
         }
-        // if we're here the input was not ok so reprompt
-        std::cout << "Retry: ";
     }
 }
 
@@ -89,7 +117,7 @@ double get_double(void)
  * float or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read or EOF, returns FLT_MAX.
  */
-float get_float(void)
+float get_float(const std::string &prompt)
 {
     // attempt to take a double from the user
     while (true)
@@ -100,7 +128,7 @@ float get_float(void)
         {
             // a bool to handle EOF, passed to get_string by address
             bool eof;
-            str = get_string(&eof);
+            str = get_string(prompt, &eof);
             // if EOF was read we return our sentinel value here 
             if (eof)
             {
@@ -128,28 +156,101 @@ float get_float(void)
                 }
             }
         }
-        // if we're here the input was not ok so reprompt
-        std::cout << "Retry: ";
     }
 }
 
 /**
- * TODO
+ * Reads a line of text from standard input and returns the int value of the
+ * string. If text does not represent an int user is prompted to retry. If eof
+ * or input stream corrupt (failed to read into string) or int is out of range
+ * returns INT_MAX.
  */
-int get_int(void)
+int get_int(const std::string &prompt)
 {
-    // TODO
-    return 0;
+    // attempt to take an int from the user
+    while (true)
+    {
+        std::string str;
+
+        // attempt to read string input, on error or EOF return CHAR_MAX
+        try
+        {
+            // a bool to handle EOF, passed to get_string by address
+            bool eof;
+            str = get_string(prompt, &eof);
+            
+            // if EOF was read we return our sentinel value here 
+            if (eof)
+            {
+                return INT_MAX;
+            }
+        }
+        catch (const std::runtime_error&)
+        {
+            return INT_MAX;
+        }
+
+        // check if input has no whitespace at beginning
+        if (str.length() > 0 && !isspace(str[0]))
+        {
+            std::istringstream iss(str);
+            int ret;
+
+            // return if iss successfully read into an int and iss exhausted
+            if (iss >> ret && iss.eof())
+            {
+                return ret;
+            }
+        }
+    }
 }
 
 /**
- * TODO
+ * Reads a line of text from standard input and returns the equivalent long
+ * long int; if string does not represent a long long int, user is prompted to
+ * retry. If eof or input stream corrupt (failed to read into string) or out of
+ * range returns LLONG_MAX.
  */
-long long get_long_long(void)
+long long get_long_long(const std::string &prompt)
 {
-    // TODO
-    return 0;
+    // attempt to take an int from the user
+    while (true)
+    {
+        std::string str;
+
+        // attempt to read string input, on error or EOF return LLONG_MAX
+        try
+        {
+            // a bool to handle EOF, passed to get_string by address
+            bool eof;
+            str = get_string(prompt, &eof);
+            
+            // if EOF was read we return our sentinel value here 
+            if (eof)
+            {
+                return LLONG_MAX;
+            }
+        }
+        catch (const std::runtime_error&)
+        {
+            return LLONG_MAX;
+        }
+
+        // check if there's input with no whitespace at the beginning
+        if (str.length() > 0 && !isspace(str[0]))
+        {
+            std::istringstream iss(str);
+            long long ret;
+
+            // return when iss successfully read into long long & iss exhausted
+            if (iss >> ret && iss.eof())
+            {
+                return ret;
+            }
+        }
+    }
 }
+
 
 /**
  * reads a line of text from standard input and returns it as std::string. It
@@ -159,11 +260,12 @@ long long get_long_long(void)
  * issues) throws std::runtime_error object. If EOF is read returns empty
  * string after setting the guard bool to true if applicable 
  */
-std::string get_string(bool *is_eof)
+std::string get_string(const std::string &prompt = std::string(), bool *is_eof = NULL)
 {
     std::string str;
 
-    // attempt to read string input into str
+    // prompt and attempt to read string input into str
+    std::cout << prompt;
     std::getline(std::cin, str);
 
     // handle EOF, input fail and bad input, clear cin error flags

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -213,7 +213,7 @@ int get_int(const std::string &prompt = std::string())
  */
 long long get_long_long(const std::string &prompt = std::string())
 {
-    // attempt to take an int from the user
+    // attempt to take a long long int from the user
     while (true)
     {
         std::string str;

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -1,12 +1,9 @@
-#include <cerrno>
 #include <cfloat>
-#include <cmath>
 #include <cstdlib>
-#include <cstring>
 #include <iostream>
-#include <string>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 #include "cs50.h"
 
@@ -61,8 +58,6 @@ std::string read_input(bool *ok)
     *ok = true;
     return str;
 }
-
-
 
 /**
  * TODO

--- a/src/cs50.cpp
+++ b/src/cs50.cpp
@@ -24,42 +24,6 @@ void eprintf()
 }
 
 /**
- * Reads a line of text from standard input and returns it as a std::string;
- * The function is used internally for reading input and handling console input
- * stream errors. If eof or input stream corrupt (failed to read into string).
- * The argument passed to bool *ok is used to check for eof or bad string input
- * so it's set to false when read fails or is in eof state, and set to true
- * otherwise.
- */
-std::string read_input(bool *ok)
-{
-    std::string str;
-
-    // attempt to read string input into s
-    std::getline(std::cin, str);
-
-    // check if input stream in bad state (hardware failure?)
-    if (std::cin.bad())
-    {
-        // if we're here we can't recover the cin stream
-        // we only get here in case of catastrophic error so throw
-        throw (std::runtime_error("cs50::input_string: error reading input"));
-    }
-
-    if (std::cin.eof() || std::cin.fail())
-    {
-        // report bad string input via side-effect and clear cin flags
-        *ok = false;
-        std::cin.clear();
-        return std::string();
-    }
-
-    // if we're here all is ok so we set sentinel to true and return the input
-    *ok = true;
-    return str;
-}
-
-/**
  * TODO
  */
 char get_char(void)
@@ -79,10 +43,13 @@ double get_double(void)
     // attempt to take a double from the user
     while (true)
     {
-        bool valid;
-        std::string str = read_input(&valid);
+        std::string str;
         // if eof or error return DBL_MAX
-        if (!valid)
+        try
+        {
+            str = get_string();
+        }
+        catch (const std::domain_error& e)
         {
             return DBL_MAX;
         }
@@ -119,10 +86,13 @@ float get_float(void)
     // attempt to take a double from the user
     while (true)
     {
-        bool valid;
-        std::string str = read_input(&valid);
-        // if eof or error, return FLT_MAX
-        if (!valid)
+        std::string str;
+        // if eof or error return FLT_MAX
+        try
+        {
+            str = get_string();
+        }
+        catch (const std::domain_error& e)
         {
             return FLT_MAX;
         }
@@ -167,19 +137,37 @@ long long get_long_long(void)
 }
 
 /**
- * TODO
+ * reads a line of text from standard input and returns it as std::string. If
+ * input stream goes bad (should never happen barring hardware issues) throws
+ * std::runtime_error object. If input is invalid (e.g. EOF etc)
+ * std::domain_error exception is thrown.
  */
 std::string get_string(void)
 {
     // TODO: decide whether to return string or c_str
-    bool valid;
-    std::string s = read_input(&valid);
+    std::string str;
 
-    // return empty string on invalid input
-    if (valid == false)
+    // attempt to read string input into str
+    std::getline(std::cin, str);
+
+    // check if input stream in bad state (hardware failure?)
+    if (std::cin.bad())
     {
-        return std::string();
+        // if we're here we can't recover the cin stream
+        // we only get here in case of catastrophic error so throw
+        throw (std::runtime_error("cs50::get_string: error reading input"));
     }
-    return s;
+
+    if (std::cin.eof() || std::cin.fail())
+    {
+        // reset cin flags, enabling further input
+        std::cin.clear();
+
+        // throw exception on bad input
+        throw std::domain_error("cs50::get_string: bad input");
+    }
+
+    // if we're here all is ok so we return the input
+    return str;
 }
 }

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -3,6 +3,20 @@
 namespace cs50
 {
 
+/** Creates a class in which the constructor cancels buffering for cout.
+ * The class gets instantiated in cs50.cpp via a static member and, therefore,
+ * it gets created before main() gets called. 
+*/
+ 
+class BeforeMain
+{
+	public:
+		BeforeMain() 
+		{ 
+			std::cout.setf(std::ios::unitbuf); 
+		}
+};
+
 /**
  * TODO
  */

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -26,7 +26,7 @@ void eprintf();
 /**
  * TODO
  */
-char get_char(void);
+char get_char(const std::string &prompt);
 
 /**
  * Reads a line of text from standard input and returns the equivalent
@@ -34,7 +34,7 @@ char get_char(void);
  * double or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read or EOF, returns DBL_MAX.
  */
-double get_double(void);
+double get_double(const std::string &prompt);
 
 /**
  * Reads a line of text from standard input and returns the equivalent
@@ -42,17 +42,17 @@ double get_double(void);
  * float or if value would cause underflow or overflow, user is
  * prompted to retry. If line can't be read or EOF, returns FLT_MAX.
  */
-float get_float(void);
+float get_float(const std::string &prompt);
 
 /**
  * TODO
  */
-int get_int(void);
+int get_int(const std::string &prompt);
 
 /**
  * TODO
  */
-long long get_long_long(void);
+long long get_long_long(const std::string &prompt);
 
 /**
  * reads a line of text from standard input and returns it as std::string. It
@@ -62,5 +62,5 @@ long long get_long_long(void);
  * issues) throws std::runtime_error object. If EOF is read returns empty
  * string after setting the guard bool to true if applicable 
  */
-std::string get_string(bool *is_eof = NULL);
+std::string get_string(const std::string &prompt, bool *is_eof);
 }

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -3,7 +3,8 @@
 namespace cs50
 {
 
-/** Creates a class in which the constructor cancels buffering for cout.
+/** 
+ * Creates a class in which the constructor cancels buffering for cout.
  * The class gets instantiated in cs50.cpp via a static member and, therefore,
  * it gets created before main() gets called. 
 */

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -29,12 +29,18 @@ void eprintf();
 char get_char(void);
 
 /**
- * TODO
+ * Reads a line of text from standard input and returns the equivalent
+ * double as precisely as possible; if text does not represent a
+ * double or if value would cause underflow or overflow, user is
+ * prompted to retry. If line can't be read or EOF, returns DBL_MAX.
  */
 double get_double(void);
 
 /**
- * TODO
+ * Reads a line of text from standard input and returns the equivalent
+ * float as precisely as possible; if text does not represent a
+ * float or if value would cause underflow or overflow, user is
+ * prompted to retry. If line can't be read or EOF, returns FLT_MAX.
  */
 float get_float(void);
 
@@ -49,8 +55,12 @@ int get_int(void);
 long long get_long_long(void);
 
 /**
- * TODO
+ * reads a line of text from standard input and returns it as std::string. It
+ * takes an optional bool pointer argument to signify EOF to the caller.
+ * is_eof's default argument is NULL.
+ * If input stream goes bad or read fails (should never happen barring hardware 
+ * issues) throws std::runtime_error object. If EOF is read returns empty
+ * string after setting the guard bool to true if applicable 
  */
-std::string get_string(void);
-
+std::string get_string(bool *is_eof = NULL);
 }


### PR DESCRIPTION
Doesn't currently work correctly on the IDE because of issues of gcc with regex. According to the gnu documentation, the earliest version that works correctly is 4.9. Just let me know in case there's any issues because of this. Otherwise, I've tested it and works just as the current version of the c get_float() and get_double()
Hope the fork is helpful :)
